### PR TITLE
Added sPHENIX classes to ACTFW

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "acts-core"]
 	path = external/acts-core
-	url = https://github.com/osbornjd/acts-core.git
+	url = https://github.com/sPHENIX-Collaboration/acts-core.git
 [submodule "acts-fatras"]
 	path = external/acts-fatras
 	url = https://github.com/sPHENIX-Collaboration/acts-fatras.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "acts-core"]
 	path = external/acts-core
-	url = https://github.com/sPHENIX-Collaboration/acts-core.git
+	url = https://github.com/osbornjd/acts-core.git
 [submodule "acts-fatras"]
 	path = external/acts-fatras
 	url = https://github.com/sPHENIX-Collaboration/acts-fatras.git

--- a/Algorithms/Fitting/CMakeLists.txt
+++ b/Algorithms/Fitting/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   ACTFWFitting SHARED
+  src/TrkrClusterFittingAlgorithmFitterFunction.cpp
   src/FittingAlgorithm.cpp
   src/FittingAlgorithmFitterFunction.cpp)
 target_include_directories(

--- a/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
+++ b/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <random>
+#include <stdexcept>
+#include <boost/program_options.hpp>
+
+#include <Acts/Fitter/GainMatrixSmoother.hpp>
+#include <Acts/Fitter/GainMatrixUpdater.hpp>
+#include <Acts/Geometry/GeometryID.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/MagneticField/SharedBField.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+#include <Acts/Fitter/KalmanFitter.hpp>
+#include <Acts/Geometry/TrackingGeometry.hpp>
+
+#include "ACTFW/Plugins/BField/ScalableBField.hpp"
+#include "ACTFW/EventData/Track.hpp"
+#include "ACTFW/Framework/BareAlgorithm.hpp"
+#include "ACTFW/Plugins/BField/BFieldOptions.hpp"
+#include "ACTFW/EventData/TrkrClusterSourceLink.hpp"
+
+namespace FW {
+
+/**
+ * This class contains the information required to run the Kalman fitter
+ * with the TrkrClusterSourceLinks. Based on FW::FittingAlgorithm
+ */
+class TrkrClusterFittingAlgorithm final : public FW::BareAlgorithm
+{
+public:
+  /// Construct some aliases to be used for the fitting results
+  using FitterResult
+    = Acts::Result<Acts::KalmanFitterResult<FW::Data::TrkrClusterSourceLink>>;
+  using FitterFunction
+    = std::function<FitterResult(const std::vector<FW::Data::TrkrClusterSourceLink>&,
+                                 const FW::TrackParameters&,
+                                 const Acts::KalmanFitterOptions&)>;
+
+  /// Create fitter function
+  static FitterFunction
+  makeFitterFunction(
+      std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+      FW::Options::BFieldVariant                    magneticField,
+      Acts::Logging::Level                          lvl);
+
+  struct Config
+  {
+    FitterFunction fit;
+  };
+
+  /// Constructor 
+  TrkrClusterFittingAlgorithm(Config cfg, Acts::Logging::Level lvl);
+
+
+private:
+  Config m_cfg;
+};
+
+}
+

--- a/Algorithms/Fitting/src/TrkrClusterFittingAlgorithmFitterFunction.cpp
+++ b/Algorithms/Fitting/src/TrkrClusterFittingAlgorithmFitterFunction.cpp
@@ -1,0 +1,84 @@
+#include "ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp"
+
+#include <iostream>
+#include <map>
+#include <random>
+#include <stdexcept>
+
+#include <Acts/Fitter/GainMatrixSmoother.hpp>
+#include <Acts/Fitter/GainMatrixUpdater.hpp>
+#include <Acts/Geometry/GeometryID.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/MagneticField/SharedBField.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+#include <boost/program_options.hpp>
+
+#include "ACTFW/Plugins/BField/ScalableBField.hpp"
+
+
+/**
+ * Struct that calls the fitting algorithm to get the result of the fit
+ */
+namespace {
+template <typename Fitter>
+struct TrkrFitterFunctionImpl
+{
+  Fitter fitter;
+
+  TrkrFitterFunctionImpl(Fitter&& f) : fitter(std::move(f)) {}
+
+  FW::TrkrClusterFittingAlgorithm::FitterResult
+  operator()(const std::vector<FW::Data::TrkrClusterSourceLink>& sourceLinks,
+             const FW::TrackParameters&                  initialParameters,
+             const Acts::KalmanFitterOptions&            options) const
+  {
+    return fitter.fit(sourceLinks, initialParameters, options);
+  };
+};
+}  // namespace
+
+/**
+ * Function that actually makes the fitting function to be used 
+ */
+FW::TrkrClusterFittingAlgorithm::FitterFunction
+FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+    FW::Options::BFieldVariant                    magneticField,
+    Acts::Logging::Level                          level)
+{
+  using Updater  = Acts::GainMatrixUpdater<Acts::BoundParameters>;
+  using Smoother = Acts::GainMatrixSmoother<Acts::BoundParameters>;
+
+  /// Return a new instance of the fitter
+  return std::visit(
+      [trackingGeometry, level](auto&& inputField) -> FitterFunction {
+	/// Construct some aliases for the components below
+        using InputMagneticField = typename std::decay_t<decltype(inputField)>::element_type;
+        using MagneticField      = Acts::SharedBField<InputMagneticField>;
+        using Stepper            = Acts::EigenStepper<MagneticField>;
+        using Navigator          = Acts::Navigator;
+        using Propagator         = Acts::Propagator<Stepper, Navigator>;
+        using Fitter             = Acts::KalmanFitter<Propagator, Updater, Smoother>;
+
+        /// Make the components for the fitter
+        MagneticField field(std::move(inputField));
+        Stepper       stepper(std::move(field));
+        Navigator     navigator(trackingGeometry);
+        navigator.resolvePassive   = false;
+        navigator.resolveMaterial  = true;
+        navigator.resolveSensitive = true;
+        Propagator propagator(std::move(stepper), std::move(navigator));
+        Fitter     fitter(std::move(propagator),
+                      Acts::getDefaultLogger("KalmanFitter", level));
+
+        /// Build the fitter function
+        return TrkrFitterFunctionImpl<Fitter>(std::move(fitter));
+      },
+      std::move(magneticField));
+}

--- a/Core/include/ACTFW/EventData/TrkrClusterSourceLink.hpp
+++ b/Core/include/ACTFW/EventData/TrkrClusterSourceLink.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <Acts/EventData/Measurement.hpp>
+#include <Acts/EventData/MeasurementHelpers.hpp>
+#include <Acts/EventData/SourceLinkConcept.hpp>
+#include <Acts/EventData/detail/fittable_type_generator.hpp>
+#include <Acts/Geometry/GeometryID.hpp>
+
+#include "ACTFW/EventData/DataContainers.hpp"
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+
+namespace FW {
+  namespace Data {
+
+/**
+ * This class creates an Acts::SourceLink that relates TrkrClusters to the
+ * surface they were measured on. The source link is needed for the fitting
+ */
+class TrkrClusterSourceLink
+{
+public:
+
+  /// Instantiate with a hitid, associated surface, and values that actually
+  /// make the measurement. Acts requires the surface be available in this class
+  TrkrClusterSourceLink(unsigned int hitid,
+			std::shared_ptr<const Acts::Surface> surface,
+			Acts::BoundVector loc,
+			Acts::BoundMatrix cov)
+    : m_hitid(hitid)
+    , m_surface(surface)
+    , m_geoId(surface->geoID())
+    , m_loc(loc)
+    , m_cov(cov)
+{
+}
+
+  /// Must be default constructible to satisfy SourceLinkConcept
+  TrkrClusterSourceLink()    = default;
+  TrkrClusterSourceLink(TrkrClusterSourceLink&&)      = default;
+  TrkrClusterSourceLink(const TrkrClusterSourceLink&) = default;
+
+  /// Needs equality operators defined to satisfy SourceLinkConcept
+  TrkrClusterSourceLink& operator=(TrkrClusterSourceLink&&)      = default;
+  TrkrClusterSourceLink& operator=(const TrkrClusterSourceLink&) = default;
+  
+  const Acts::GeometryID geoId() const 
+  {
+    return m_geoId;
+  }
+
+  /// Needs referenceSurface function to satisfy SourceLinkConcept
+  const Acts::Surface& referenceSurface() const 
+  {
+    return *m_surface;
+  }
+  
+  /// Create Acts::FittableMeasurement from information in SourceLink
+  Acts::FittableMeasurement<TrkrClusterSourceLink> operator*() const
+  {
+
+    return Acts::Measurement<TrkrClusterSourceLink, 
+			     Acts::ParDef::eLOC_0,
+			     Acts::ParDef::eLOC_1>
+      {
+	m_surface,
+	  *this,
+	  m_cov.topLeftCorner<2, 2>(),
+	  m_loc[0],
+	  m_loc[1]};
+  }
+
+  const unsigned int hitID() const
+  {
+    return m_hitid;
+  }
+
+
+private:
+  
+  /// Hitindex corresponding to hitID and the corresponding 
+  /// surface to which it belongs to
+  unsigned int m_hitid;
+  std::shared_ptr<const Acts::Surface> m_surface;
+  Acts::GeometryID m_geoId;
+
+  /// Local x and y position for cluster
+  Acts::BoundVector m_loc;
+  /// Cluster covariance matrix
+  Acts::BoundMatrix m_cov;
+
+  /// Needs equality operator defined to satisfy SourceLinkConcept
+  /// Equate the cluster keys
+  friend constexpr bool
+  operator==(const TrkrClusterSourceLink& lhs, const TrkrClusterSourceLink& rhs)
+  {
+    return lhs.m_hitid == rhs.m_hitid;
+  }
+
+};
+
+    /// Ensure that the SourceLink class satisfies SourceLinkConcept conditions
+    static_assert(Acts::SourceLinkConcept<TrkrClusterSourceLink>, 
+		  "TrkrClusterSourceLink does not fulfill SourceLinkConcept");
+  }
+
+
+  // Construct a container for TrkrSourceLinks
+  using TrkrClusterSourceLinkContainer = GeometryIdMultiset<Data::TrkrClusterSourceLink>;
+  
+
+}


### PR DESCRIPTION
By putting these sPHENIX specific ACTFW classes in the ACTFW repository, the linking is handled on the cmake and ACTFW side and thus recompiling the trackreco package in coresoftware is faster. Regardless, these should really exist here since they don't rely on any sPHENIX code, only Acts code.